### PR TITLE
feat(TASK-06): adding the button to display the 20 next pokemon from the API

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: "Square";
+  src: url("./fonts/Square.ttf") format("truetype");
+}
+
 #root {
   max-width: 80rem;
   margin: 0 auto;
@@ -10,4 +15,16 @@
   justify-content: center;
   align-items: center;
   margin-bottom: 10%;
+}
+
+.load__more__button {
+  display: flex;
+  justify-content: end;
+  margin-top: 60px;
+}
+
+.load__more__button button {
+  background-color: rgb(239, 66, 66);
+  color: white;
+  font-family: "Square", sans-serif;
 }

--- a/src/components/card/PokemonCard.css
+++ b/src/components/card/PokemonCard.css
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: "Square";
+  src: url("./fonts/Square.ttf") format("truetype");
+}
+
 .cards {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -13,6 +18,7 @@
   border-radius: 20px;
   box-shadow: 10px 10px 10px rgba(68, 66, 66, 0.5);
   border: 2px solid black;
+  cursor: pointer;
 }
 
 .card__header {
@@ -29,7 +35,6 @@
 }
 
 .card__footer__sprite {
-  justify-content: end;
   margin: 10px;
 }
 
@@ -66,15 +71,16 @@
 .card__footer__button button {
   background-color: #a90000;
   cursor: pointer;
+  font-family: "Square", sans-serif;
 }
 
 @media (max-width: 600px) {
   #root {
-    padding: 10px;
+    padding: 70px;
   }
 
   #header img {
-    width: 80%;
+    width: 70%;
   }
 
   .cards {
@@ -94,16 +100,21 @@
   }
 
   .card__header__id {
-    font-size: 16px;
+    font-size: 20px;
     margin-right: 5px;
   }
 
-  .name {
-    font-size: 18px;
+  .card__footer__sprite {
+    display: flex;
+    justify-content: center;
   }
 
   .card__footer__sprite img {
     height: 150px;
     width: 150px;
+  }
+
+  .card__footer__button {
+    margin-bottom: 5px;
   }
 }

--- a/src/components/pokemonTypeBadge/PokemonTypeBadge.css
+++ b/src/components/pokemonTypeBadge/PokemonTypeBadge.css
@@ -11,6 +11,7 @@
 .type__badge span {
   padding: 5px 15px;
   border-radius: 50px;
+  margin-left: 2px;
   color: white;
   font-family: "Square", sans-serif;
 }

--- a/src/services/Pokemon.service.ts
+++ b/src/services/Pokemon.service.ts
@@ -1,9 +1,12 @@
 import { PaginatedResult, PokemonLight, PokemonDetail } from "../types/Pokemon.type";
 
-export async function fetchPokemonList(): Promise<PokemonLight[]> {
+export async function fetchPokemonList(): Promise<{
+  results: PokemonLight[];
+  next: string | null;
+}> {
   const response = await fetch("https://pokeapi.co/api/v2/pokemon?limit=20&offset=0");
   const data: PaginatedResult<PokemonLight> = await response.json();
-  return data.results;
+  return { results: data.results, next: data.next };
 }
 
 export async function fetchPokemonDetail(url: string): Promise<PokemonDetail> {


### PR DESCRIPTION
If you have questions about the project, ask me directly by commenting the PR

+ adding a few CSS lines for the mobile version

Some of the new pokemon (so some after the 20 first
<img width="1244" alt="Capture d’écran 2025-02-28 à 14 24 55" src="https://github.com/user-attachments/assets/922323c3-1108-4e34-93ab-db4827b13462" />
 ones



Responsif for the mobile version : 
<img width="414" alt="Capture d’écran 2025-02-28 à 14 26 10" src="https://github.com/user-attachments/assets/6e31dbb8-adfb-4efd-b299-f5caa25571a5" />
